### PR TITLE
Use Sphinx 1.x in GCC 4.8 image

### DIFF
--- a/gcc48/Dockerfile
+++ b/gcc48/Dockerfile
@@ -34,7 +34,7 @@ RUN dpkg --add-architecture i386 \
         zlib1g-dev:i386 \
  && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --compile sphinx 'requests>=2.4.1'
+RUN pip3 install --compile 'sphinx<2.0' 'requests>=2.4.1'
 
 RUN mkdir -p /osxcross/tarballs /opt/cmake /usr/src/ccache \
  && cd /osxcross/tarballs \


### PR DESCRIPTION
Sphinx 2.0 doesn't support Python 3.4, and specifying the Sphinx version is probably easier than upgrading Python.