### PR TITLE
MSVC: don't wait for wineserver to exit

### DIFF
--- a/msvc/wrapper
+++ b/msvc/wrapper
@@ -12,7 +12,6 @@ done
 
 if [[ "$(basename "$0")" == "clcache" ]]; then
 	if wine "$(basename "$0")" "${args[@]}" < /dev/null; then
-		wineserver -w
 		exit
 	else
 		echo "[DFHack] attempting again with clcache disabled."
@@ -21,5 +20,3 @@ if [[ "$(basename "$0")" == "clcache" ]]; then
 fi
 
 wine "$(basename "$0")" "${args[@]}" < /dev/null
-
-wineserver -w


### PR DESCRIPTION
`wineserver -w` waits for a global wineserver instance to exit, meaning that even though Buildmaster runs 14 jobs in parallel, MSVC jobs wait for *all* other running wine processes to finish before exiting. Some tests with wine on `buildpack-deps:bionic` suggest that `wine` returns when the process it's running terminates, so this may not be necessary.

Note that this is not tested with MSVC itself, which may behave differently.