### PR TITLE
Upgrade GCC 4.8 image to Python 3.6

### DIFF
--- a/gcc48/Dockerfile
+++ b/gcc48/Dockerfile
@@ -26,15 +26,22 @@ RUN dpkg --add-architecture i386 \
         libxml-libxslt-perl \
         mesa-common-dev \
         ninja-build \
-        python3-dev \
-        python3-pip \
         ruby \
+        software-properties-common \
         xvfb \
         zlib1g-dev:amd64 \
         zlib1g-dev:i386 \
+ && add-apt-repository -y ppa:deadsnakes/ppa \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3.6 \
+ && apt-get remove -y software-properties-common \
+ && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --compile 'sphinx<2.0' 'requests>=2.4.1'
+RUN curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.6
+
+RUN pip3 install --compile sphinx 'requests>=2.4.1'
 
 RUN mkdir -p /osxcross/tarballs /opt/cmake /usr/src/ccache \
  && cd /osxcross/tarballs \


### PR DESCRIPTION
This allows upgrading to the latest version of Sphinx, which dropped Python 3.4 compatibility in 2.x. Newer versions of Sphinx hopefully resolve the intermittent docs build failures we see specific to this image, e.g. in https://buildmaster.lubar.me/applications/3/builds/build?buildId=9704

```
FAILED: cd /home/buildmaster/work/_E0/build32-4.8 && /usr/local/bin/sphinx-build -a -E -q -b html /home/buildmaster/work/_E0/src /home/buildmaster/work/_E0/src/docs/html -w /home/buildmaster/work/_E0/src/docs/_sphinx-warnings.txt -j 2

Sphinx parallel build error:
RuntimeError: maximum recursion depth exceeded while pickling an object
```

Tested by building the image until the `pip3 install` step finished, then running `sphinx-build --version` in the image.