### PR TITLE
Update build images to use cmake-3.22.4

### DIFF
--- a/gcc48/Dockerfile
+++ b/gcc48/Dockerfile
@@ -45,12 +45,12 @@ RUN pip3 install --compile sphinx 'requests>=2.4.1'
 
 RUN mkdir -p /osxcross/tarballs /opt/cmake /usr/src/ccache \
  && cd /osxcross/tarballs \
- && curl -LSo cmake.tar.gz https://cmake.org/files/v3.11/cmake-3.11.4-Linux-x86_64.tar.gz \
+ && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.4/cmake-3.22.4-linux-x86_64.tar.gz \
  && curl -LSo osxcross.tar.gz https://github.com/tpoechtrager/osxcross/archive/1a1733a773fe26e7b6c93b16fbf9341f22fac831.tar.gz \
  && curl -LSo MacOSX10.10.sdk.tar.xz https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.10.sdk.tar.xz \
  && curl -LSo gcc-4.8.5.tar.gz https://ftpmirror.gnu.org/gcc/gcc-4.8.5/gcc-4.8.5.tar.gz \
  && curl -LSo ccache-4.2.tar.xz https://github.com/ccache/ccache/releases/download/v4.2/ccache-4.2.tar.xz \
- && (echo "6dab016a6b82082b8bcd0f4d1e53418d6372015dd983d29367b9153f1a376435  cmake.tar.gz"; \
+ && (echo "bb70a78b464bf59c4188250f196ad19996f2dafd61c25e7c07f105cf5a95d228  cmake.tar.gz"; \
      echo "c6cead036022edb7013a6adebf5c6832e06d5281b72515b10890bf91b8fe9ada  osxcross.tar.gz"; \
      echo "4a08de46b8e96f6db7ad3202054e28d7b3d60a3d38cd56e61f08fb4863c488ce  MacOSX10.10.sdk.tar.xz"; \
      echo "1dbc5cd94c9947fe5dffd298e569de7f44c3cedbd428fceea59490d336d8295a  gcc-4.8.5.tar.gz"; \

--- a/gcc7/Dockerfile
+++ b/gcc7/Dockerfile
@@ -45,12 +45,12 @@ RUN pip3 install --compile sphinx
 
 RUN mkdir -p /osxcross/tarballs /opt/cmake /usr/src/ccache \
  && cd /osxcross/tarballs \
- && curl -LSo cmake.tar.gz https://cmake.org/files/v3.11/cmake-3.11.4-Linux-x86_64.tar.gz \
+ && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.4/cmake-3.22.4-linux-x86_64.tar.gz \
  && curl -LSo osxcross.tar.gz https://github.com/tpoechtrager/osxcross/archive/1a1733a773fe26e7b6c93b16fbf9341f22fac831.tar.gz \
  && curl -LSo MacOSX10.10.sdk.tar.xz https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.10.sdk.tar.xz \
  && curl -LSo gcc-7.5.0.tar.gz https://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz \
  && curl -LSo ccache-4.2.tar.xz https://github.com/ccache/ccache/releases/download/v4.2/ccache-4.2.tar.xz \
- && (echo "6dab016a6b82082b8bcd0f4d1e53418d6372015dd983d29367b9153f1a376435  cmake.tar.gz"; \
+ && (echo "bb70a78b464bf59c4188250f196ad19996f2dafd61c25e7c07f105cf5a95d228  cmake.tar.gz"; \
      echo "c6cead036022edb7013a6adebf5c6832e06d5281b72515b10890bf91b8fe9ada  osxcross.tar.gz"; \
      echo "4a08de46b8e96f6db7ad3202054e28d7b3d60a3d38cd56e61f08fb4863c488ce  MacOSX10.10.sdk.tar.xz"; \
      echo "4f518f18cfb694ad7975064e99e200fe98af13603b47e67e801ba9580e50a07f  gcc-7.5.0.tar.gz"; \

--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -16,10 +16,10 @@ RUN dpkg --add-architecture i386 \
  && useradd --uid 1001 --create-home --shell /bin/bash buildmaster \
  && mkdir -p /opt/cmake \
  && cd /opt \
- && curl -LSo cmake.tar.gz https://cmake.org/files/v3.11/cmake-3.11.4-Linux-x86_64.tar.gz \
- && echo "6dab016a6b82082b8bcd0f4d1e53418d6372015dd983d29367b9153f1a376435  cmake.tar.gz" | sha256sum -c \
+ && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.4/cmake-3.22.4-linux-x86_64.tar.gz \
+ && echo "bb70a78b464bf59c4188250f196ad19996f2dafd61c25e7c07f105cf5a95d228  cmake.tar.gz" | sha256sum -c \
  && tar xzCf /opt/cmake /opt/cmake.tar.gz --strip-components=1 \
- && sed -e 's#/Zi#/Z7#g' -i /opt/cmake/share/cmake-3.11/Modules/Platform/Windows-MSVC.cmake \
+ && sed -e 's#/Zi#/Z7#g' -i /opt/cmake/share/cmake-3.22/Modules/Platform/Windows-MSVC.cmake \
  && rm -f /opt/cmake.tar.gz
 
 RUN pip3 install --compile sphinx


### PR DESCRIPTION
Our dependencies are starting to complain that we're using such an old cmake version (3.11.4). This PR upgrades all three build images to cmake-3.22.4. It's the most stable recent release. Is there any risk in using such a recent version? Do we want to ensure a particular older version still works?

@lethosor any thoughts on this?