### PR TITLE
Explicitly set CMAKE_AR

### DIFF
--- a/msvc/toolchain.cmake
+++ b/msvc/toolchain.cmake
@@ -8,6 +8,7 @@ set(CMAKE_C_COMPILER_ID MSVC)
 set(CMAKE_C_PLATFORM_ID Windows)
 set(CMAKE_C_COMPILER /usr/local/bin/cl)
 set(CMAKE_LINKER /usr/local/bin/link)
+set(CMAKE_AR ${CMAKE_LINKER})
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Release") #|RelWithDebInfo
 set(CMAKE_CROSS_COMPILING ON)
 set(MSVC_VERSION 1900)


### PR DESCRIPTION
It's hard to find what this should be set to. Most examples online use msys or llvm. The one example I found that seems to use the MSVC toolchain is https://www.mail-archive.com/cmake@cmake.org/msg61272.html which indicates that the linker also serves as the archiver. I have no experience with the MSVC toolchain, though, and I have no idea whether this is accurate.