### PR TITLE
downgrade cmake to 3.17.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   - Linux and Mac OS X
   - Minimum OS X version 10.6
 - ccache (intended to have cache directory stored outside the container)
-- CMake version 3.11 or later
+- CMake version 3.17 or later
 - Google protocol buffer compiler (shim DFHack native build directory at `/home/buildmaster/dfhack-native`)
 - Perl with `XML::LibXML` and `XML::LibXSLT` (required for df-structures)
 - OpenGL headers and libraries (required for Stonesense)
@@ -35,7 +35,7 @@
   - Linux and Mac OS X
   - Minimum OS X version 10.6
 - ccache (intended to have cache directory stored outside the container)
-- CMake version 3.11 or later
+- CMake version 3.17 or later
 - Google protocol buffer compiler (shim DFHack native build directory at `/home/buildmaster/dfhack-native`)
 - Perl with `XML::LibXML` and `XML::LibXSLT` (required for df-structures)
 - OpenGL headers and libraries (required for Stonesense)
@@ -50,7 +50,7 @@
 - buildpack-deps (see [Docker Hub](https://hub.docker.com/_/buildpack-deps/) description for details)
 - Microsoft Visual C++ 2015 compilers (update 3 or later)
 - ccache (experimental branch that supports MSVC) (intended to have cache directory stored outside the container)
-- CMake version 3.11 or later
+- CMake version 3.17 or later
 - Google protocol buffer compiler (shim DFHack native build directory at `/home/buildmaster/dfhack-native`)
 - Perl with `XML::LibXML` and `XML::LibXSLT` (required for df-structures)
 - Sphinx (used to build DFHack documentation)

--- a/gcc48/Dockerfile
+++ b/gcc48/Dockerfile
@@ -44,12 +44,12 @@ RUN pip3 install --compile sphinx 'requests>=2.4.1'
 
 RUN mkdir -p /osxcross/tarballs /opt/cmake /usr/src/ccache \
  && cd /osxcross/tarballs \
- && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.4/cmake-3.22.4-linux-x86_64.tar.gz \
+ && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.17.5/cmake-3.17.5-Linux-x86_64.tar.gz \
  && curl -LSo osxcross.tar.gz https://github.com/tpoechtrager/osxcross/archive/1a1733a773fe26e7b6c93b16fbf9341f22fac831.tar.gz \
  && curl -LSo MacOSX10.10.sdk.tar.xz https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.10.sdk.tar.xz \
  && curl -LSko gcc-4.8.5.tar.gz https://ftpmirror.gnu.org/gcc/gcc-4.8.5/gcc-4.8.5.tar.gz \
  && curl -LSo ccache-4.2.tar.xz https://github.com/ccache/ccache/releases/download/v4.2/ccache-4.2.tar.xz \
- && (echo "bb70a78b464bf59c4188250f196ad19996f2dafd61c25e7c07f105cf5a95d228  cmake.tar.gz"; \
+ && (echo "897142368b15a5693c999a7ed2187be20c1b41a68c3711379d32a33469bb29ba  cmake.tar.gz"; \
      echo "c6cead036022edb7013a6adebf5c6832e06d5281b72515b10890bf91b8fe9ada  osxcross.tar.gz"; \
      echo "4a08de46b8e96f6db7ad3202054e28d7b3d60a3d38cd56e61f08fb4863c488ce  MacOSX10.10.sdk.tar.xz"; \
      echo "1dbc5cd94c9947fe5dffd298e569de7f44c3cedbd428fceea59490d336d8295a  gcc-4.8.5.tar.gz"; \

--- a/gcc7/Dockerfile
+++ b/gcc7/Dockerfile
@@ -46,12 +46,12 @@ RUN pip3 install --compile sphinx
 
 RUN mkdir -p /osxcross/tarballs /opt/cmake /usr/src/ccache \
  && cd /osxcross/tarballs \
- && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.4/cmake-3.22.4-linux-x86_64.tar.gz \
+ && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.17.5/cmake-3.17.5-Linux-x86_64.tar.gz \
  && curl -LSo osxcross.tar.gz https://github.com/tpoechtrager/osxcross/archive/1a1733a773fe26e7b6c93b16fbf9341f22fac831.tar.gz \
  && curl -LSo MacOSX10.10.sdk.tar.xz https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.10.sdk.tar.xz \
  && curl -LSo gcc-7.5.0.tar.gz https://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.gz \
  && curl -LSo ccache-4.2.tar.xz https://github.com/ccache/ccache/releases/download/v4.2/ccache-4.2.tar.xz \
- && (echo "bb70a78b464bf59c4188250f196ad19996f2dafd61c25e7c07f105cf5a95d228  cmake.tar.gz"; \
+ && (echo "897142368b15a5693c999a7ed2187be20c1b41a68c3711379d32a33469bb29ba  cmake.tar.gz"; \
      echo "c6cead036022edb7013a6adebf5c6832e06d5281b72515b10890bf91b8fe9ada  osxcross.tar.gz"; \
      echo "4a08de46b8e96f6db7ad3202054e28d7b3d60a3d38cd56e61f08fb4863c488ce  MacOSX10.10.sdk.tar.xz"; \
      echo "4f518f18cfb694ad7975064e99e200fe98af13603b47e67e801ba9580e50a07f  gcc-7.5.0.tar.gz"; \

--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -16,8 +16,8 @@ RUN dpkg --add-architecture i386 \
  && useradd --uid 1001 --create-home --shell /bin/bash buildmaster \
  && mkdir -p /opt/cmake \
  && cd /opt \
- && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.4/cmake-3.22.4-linux-x86_64.tar.gz \
- && echo "bb70a78b464bf59c4188250f196ad19996f2dafd61c25e7c07f105cf5a95d228  cmake.tar.gz" | sha256sum -c \
+ && curl -LSo cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.17.5/cmake-3.17.5-Linux-x86_64.tar.gz \
+ && echo "897142368b15a5693c999a7ed2187be20c1b41a68c3711379d32a33469bb29ba  cmake.tar.gz" | sha256sum -c \
  && tar xzCf /opt/cmake /opt/cmake.tar.gz --strip-components=1 \
  && sed -e 's#/Zi#/Z7#g' -i /opt/cmake/share/cmake-3.22/Modules/Platform/Windows-MSVC.cmake \
  && rm -f /opt/cmake.tar.gz

--- a/msvc/toolchain.cmake
+++ b/msvc/toolchain.cmake
@@ -8,7 +8,6 @@ set(CMAKE_C_COMPILER_ID MSVC)
 set(CMAKE_C_PLATFORM_ID Windows)
 set(CMAKE_C_COMPILER /usr/local/bin/cl)
 set(CMAKE_LINKER /usr/local/bin/link)
-set(CMAKE_AR /usr/local/bin/lib)
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Release") #|RelWithDebInfo
 set(CMAKE_CROSS_COMPILING ON)
 set(MSVC_VERSION 1900)


### PR DESCRIPTION
this is the last release that didn't use CMAKE_AR for linking static libraries. until we can figure out how to use lib.exe (see previous PRs), this is the most recent cmake version we can use.