### PR TITLE
remove ccache support

### DIFF
--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -56,9 +56,5 @@ RUN mkdir /home/buildmaster/dfhack-native \
 # Get rid of the "install mono?" and "install gecko?" prompts.
 RUN WINEDLLOVERRIDES="mscoree,mshtml=" wine64 wineboot --init && wineserver -w
 
-# Experimental: ccache with msvc support!
-# Built from https://github.com/ccache/ccache/archive/3972b9bd6f9c27df02d277d7253b316ffc125995.tar.gz
-ADD ccache.exe /home/buildmaster/.wine/drive_c/windows/system32/
-
 USER root
-ADD dfhack-configure dfhack-make dfhack-test ccache-win /usr/local/bin/
+ADD dfhack-configure dfhack-make dfhack-test /usr/local/bin/

--- a/msvc/ccache-win
+++ b/msvc/ccache-win
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-
-wine64 C:/windows/system32/ccache.exe "$@"

--- a/msvc/dfhack-configure
+++ b/msvc/dfhack-configure
@@ -18,11 +18,6 @@ bits=$2
 mode=$3
 shift 3
 
-if [[ -z "$CCACHE_BASEDIR" ]] || [[ ! -d "$CCACHE_BASEDIR" ]]; then
-	echo "The environment variable CCACHE_BASEDIR should be set to the closest parent directory of the source and build directories." >&2
-	exit 2
-fi
-
 case $os in
 windows)
 	;;
@@ -59,9 +54,7 @@ esac
 wineserver -p
 wine64 wineboot
 
-CCACHE=/usr/local/bin/ccache-win
-
-CC=cl CXX=cl cmake .. -GNinja -DDFHACK_BUILD_ARCH=$bits -DCMAKE_BUILD_TYPE=$mode -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_CROSSCOMPILING=ON -DCCACHE_EXECUTABLE=$CCACHE -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE -DCMAKE_C_COMPILER_LAUNCHER=$CCACHE -DDFHACK_NATIVE_BUILD_DIR=/home/buildmaster/dfhack-native "$@" <&0
+CC=cl CXX=cl cmake .. -GNinja -DDFHACK_BUILD_ARCH=$bits -DCMAKE_BUILD_TYPE=$mode -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_CROSSCOMPILING=ON -DDFHACK_NATIVE_BUILD_DIR=/home/buildmaster/dfhack-native "$@" <&0
 
 wineserver -k
 wineserver -w


### PR DESCRIPTION
it doesn't work with how our build system creates the build commands specifically, our build uses /showIncludes, which causes ccache to refuse to cache anything. it becomes a noop.

no need to merge this quite yet, but I wanted to get your feedback on whether ccache *ever* worked for the windows build. how did you get it working if it did?