### PR TITLE
Final msvc build image i mean it i hope

### DIFF
--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y wine64-development python3 msitools python3-simplejson python3-six ca-certificates \
- && apt-get install -y gcc g++ ninja-build zlib1g-dev libsdl1.2-dev libxml-libxml-perl libxml-libxslt-perl make libncurses-dev libssl-dev \
+ && apt-get install -y gcc g++ ninja-build git zlib1g-dev libsdl1.2-dev libxml-libxml-perl libxml-libxslt-perl make libncurses-dev libssl-dev \
  && apt-get install -y dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev \
  && apt-get install -y wget curl unzip vim bash-completion xvfb python3-pip \
  && apt-get clean -y \

--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -1,60 +1,81 @@
 FROM ubuntu:20.04
 
+# install dependencies
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y wine64-development python3 msitools python3-simplejson python3-six ca-certificates \
- && apt-get install -y gcc g++ ninja-build git zlib1g-dev libsdl1.2-dev libxml-libxml-perl libxml-libxslt-perl make libncurses-dev libssl-dev \
- && mkdir -p /opt/cmake/src && cd /opt/cmake/src \
- && git clone -b "msvc-3.22.1" --depth=1 https://gitlab.kitware.com/mstorsjo/cmake.git \
- && mkdir cmake/build && cd cmake/build && ../configure --prefix=/opt/cmake --parallel=$(nproc) -- -DBUILD_CursesDialog=ON \
- && make -j$(nproc) && make install && cd && rm -rf /opt/cmake/src \
- && apt-get install -y wget curl unzip vim bash-completion ccache xvfb python3-pip \
+ && apt-get install -y gcc g++ ninja-build zlib1g-dev libsdl1.2-dev libxml-libxml-perl libxml-libxslt-perl make libncurses-dev libssl-dev \
+ && apt-get install -y dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev \
+ && apt-get install -y wget curl unzip vim bash-completion xvfb python3-pip \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ && pip3 install --compile sphinx \
  && useradd --uid 1001 --create-home --shell /bin/bash buildmaster
 
-RUN pip3 install --compile sphinx
-
+# set up msvc
 WORKDIR /opt/msvc
-COPY lowercase fixinclude install.sh vsdownload.py ./
+COPY lowercase fixinclude install.sh vsdownload.py msvcenv-native.sh ./
 COPY wrappers/* ./wrappers/
 
-RUN PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license --dest /opt/msvc && \
-    ./install.sh /opt/msvc && \
-    rm lowercase fixinclude install.sh vsdownload.py && \
-    rm -rf wrappers
-
-COPY msvcenv-native.sh /opt/msvc
-
-USER buildmaster
-WORKDIR /home/buildmaster
+RUN PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license --dest /opt/msvc \
+ && ./install.sh /opt/msvc \
+ && rm lowercase fixinclude install.sh vsdownload.py \
+ && rm -rf wrappers
 
 ENV BIN=/opt/msvc/bin/x64 \
-    PATH=/opt/msvc:/opt/msvc/bin/x64:/opt/cmake/bin:$PATH \
+    PATH=/opt/msvc:/opt/msvc/bin/x64:/opt/git/bin:/opt/ccache/bin:/opt/cmake/bin:$PATH \
     WINEARCH=win64 \
     WINEDLLOVERRIDES='ngen.exe,mscorsvw.exe=b' \
     WINEDEBUG=-all
 
-# Add native build directory.
-# (maintainer: Update cloned git tag only if needed.)
+# compile more recent git for ssh keysigning
+RUN mkdir -p /opt/git/src && cd /opt/git/src \
+ && wget https://github.com/git/git/archive/refs/tags/v2.38.1.tar.gz \
+ && tar xzf "v2.38.1.tar.gz" \
+ && cd git-2.38.1 \
+ && make configure && ./configure --prefix=/opt/git \
+ && make -j$(nproc) all && make install \
+ && cd && rm -rf /opt/git/src
+
+# compile custom cmake for msvc and ninja compatibility
+RUN mkdir -p /opt/cmake/src && cd /opt/cmake/src \
+ && git clone -b msvc-3.22.1 --depth=1 https://gitlab.kitware.com/mstorsjo/cmake.git \
+ && mkdir cmake/build && cd cmake/build && ../configure --prefix=/opt/cmake --parallel=$(nproc) -- -DBUILD_CursesDialog=ON \
+ && make -j$(nproc) && make install \
+ && cd && rm -rf /opt/cmake/src
+
+# compile custom ccache for msvc caching
+COPY ccache-4.7.4.patch /tmp
+RUN mkdir -p /opt/ccache/src && cd /opt/ccache/src \
+ && git clone -b "v4.7.4" --depth=1 https://github.com/ccache/ccache.git \
+ && mkdir ccache/build && cd ccache && git apply /tmp/ccache-4.7.4.patch \
+ && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/ccache .. \
+ && make -j$(nproc) && make install && cd && rm -rf /opt/ccache/src
+
+# set up dfhack build environment
+USER buildmaster
+WORKDIR /home/buildmaster
+
+# Add native build directory for DFHack cross compiling
+# maintainer: Update cloned git tag when we update protobuf to keep them in sync
 RUN mkdir /home/buildmaster/dfhack-native \
  && cd /home/buildmaster/dfhack-native \
- && git clone -n https://github.com/DFHack/dfhack.git \
- && cd dfhack \
- && git checkout d21d4d7f5348942b1574d5ecad8ed3d0ba027929 \
- && git submodule update --init \
- && cd .. \
+ && git clone -b "0.47.05-r8" --depth=1 https://github.com/DFHack/dfhack.git \
+ && cd dfhack && git submodule update --init && cd .. \
  && cmake dfhack -GNinja -DCMAKE_BUILD_TYPE=Release -DDOWNLOAD_RUBY=OFF \
- && ninja protoc \
+ && ninja protoc-bin \
  && cd .. \
  && mkdir -p dfhack-native-bin/depends/protobuf \
  && mv dfhack-native/ImportExecutables.cmake dfhack-native-bin \
- && mv dfhack-native/depends/protobuf/protoc* dfhack-native-bin/depends/protobuf \
+ && mv dfhack-native/depends/protobuf/*proto* dfhack-native-bin/depends/protobuf \
  && rm -rf dfhack-native \
  && mv dfhack-native-bin dfhack-native
 
-# Get rid of the "install mono?" and "install gecko?" prompts.
-RUN WINEDLLOVERRIDES="mscoree,mshtml=" wine64 wineboot --init && wineserver -w
+# set up wine (get rid of the "install mono?" and "install gecko?" prompts) and ccache
+RUN WINEDLLOVERRIDES="mscoree,mshtml=" wine64 wineboot --init \
+ && wineserver -w \
+ && ccache -C
 
+# copy in frequently-changing scripts last so the image can be quickly rebuilt
 USER root
-ADD dfhack-configure dfhack-make dfhack-test /usr/local/bin/
+COPY dfhack-configure dfhack-make dfhack-test /usr/local/bin/

--- a/msvc/ccache-4.7.4.patch
+++ b/msvc/ccache-4.7.4.patch
@@ -1,0 +1,13 @@
+diff --git a/src/argprocessing.cpp b/src/argprocessing.cpp
+index 0bc37e57..75b7cfa2 100644
+--- a/src/argprocessing.cpp
++++ b/src/argprocessing.cpp
+@@ -287,7 +287,7 @@ process_option_arg(const Context& ctx,
+   }
+ 
+   bool changed_from_slash = false;
+-  if (ctx.config.is_compiler_group_msvc() && util::starts_with(args[i], "/")) {
++  if (ctx.config.is_compiler_group_msvc() && !state.found_c_opt && util::starts_with(args[i], "/")) {
+     // MSVC understands both /option and -option, so convert all /option to
+     // -option to simplify our handling.
+     args[i][0] = '-';

--- a/msvc/dfhack-configure
+++ b/msvc/dfhack-configure
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 usage()
 {

--- a/msvc/dfhack-make
+++ b/msvc/dfhack-make
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 . msvcenv-native.sh
 

--- a/msvc/dfhack-test
+++ b/msvc/dfhack-test
@@ -1,21 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
 
-usage()
-{
-	echo 'Usage: dfhack-test [os] [bits]' >&2
-	echo 'os: windows' >&2
-	echo 'bits: 32 or 64' >&2
-	echo '(run inside the DF folder)' >&2
-}
+. msvcenv-native.sh
 
-if [[ $# -ne 2 ]]; then
-	usage
-	exit 1
-fi
+wineserver -p
+wine wineboot
 
-os=$1
-bits=$2
-shift 2
+ninja test
 
-echo '[temporary] Skipping tests for all platforms other than 64-bit Linux.'
-exit 0
+wineserver -k
+wineserver -w


### PR DESCRIPTION
- revert to the old version of protobuf for native build. I just cannot get the linking errors with the newer version figured out : (
- add ccache back in, and patch it to work with msvc
- build a newer version of git so the image can be used more easily as a personal build environment
- fix the dfhack-* build scripts so they can be run repeatedly
- organize and reorder the steps in the dockerfile so (future) rebuilds should go quicker (i.e. steps that are more likely to change now appear later in the file)