### PR TITLE
msvc: allow specification of builder UID

### DIFF
--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ARG BUILDER_UID=1001
+
 # install dependencies
 RUN apt-get update \
  && apt-get upgrade -y \
@@ -10,7 +12,7 @@ RUN apt-get update \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install --compile sphinx \
- && useradd --uid 1001 --create-home --shell /bin/bash buildmaster
+ && useradd --uid $BUILDER_UID --create-home --shell /bin/bash buildmaster
 
 # set up msvc
 WORKDIR /opt/msvc


### PR DESCRIPTION
E.g.:

    docker build --build-arg BUILDER_UID=1000

This is useful for when you want to mount an existing source directory from the host that is owned by a specific user, and having the build work (vs cloning dfhack inside the container).