### PR TITLE
Add an entrypoint that fixes the UID on run

### DIFF
--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -81,3 +81,8 @@ RUN WINEDLLOVERRIDES="mscoree,mshtml=" wine64 wineboot --init \
 # copy in frequently-changing scripts last so the image can be quickly rebuilt
 USER root
 COPY dfhack-configure dfhack-make dfhack-test /usr/local/bin/
+
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD bash

--- a/msvc/entrypoint.sh
+++ b/msvc/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+# Default behaviour if BUILDER_UID is 0
+if [[ -z "$BUILDER_UID" ]]; then
+    exec "$@"
+fi
+
+# We can really only change users if we're root, so if we're not, just fallback
+# to running the command
+if [[ $(id -u) -ne 0 ]]; then
+    exec "$@"
+fi
+
+OLD_UID=$(id -u buildmaster)
+# Now we are root, and have BUILDER_UID set. If the UIDs mismatch for
+# buildmaster, let's fix it.
+if [[ $OLD_UID -ne $BUILDER_UID ]]; then
+    echo "Changing builder UID from $OLD_UID to $BUILDER_UID"
+    userdel buildmaster
+
+    useradd -u $BUILDER_UID --shell /bin/bash buildmaster
+
+    find / -xdev -uid $OLD_UID -exec chown buildmaster {} +
+fi
+
+# Preserve PATH cause su overrides it
+exec su buildmaster -c 'env PATH='"$PATH"' "$0" "$@"' -- "$@"


### PR DESCRIPTION
If they don't match, then this fixes all the files in the image during a docker run.

This makes it so that the same image can work with multiple UIDs.

Example usage:

docker run --rm -it -v "$PWD":/src -e BUILDER_UID=1000 --name dfhack-win dfhack-build-msvc bash

Note that I have not tested this with the buildmaster builds, so I can't guarantee this won't break it, but would love to either learn now to test it, or have someone test this for me.

This allows this builder image to work for any UID without a complete rebuild, which some have found to be painful.