### PR TITLE
Add Github Actions build

### DIFF
--- a/.github/workflows/msvc-cross-build.yml
+++ b/.github/workflows/msvc-cross-build.yml
@@ -1,0 +1,33 @@
+name: Build and Push Docker Image
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    # From https://github.com/docker/build-push-action#git-context
+    # Setting up Docker Buildx with docker-container driver is required
+    # at the moment to be able to use a subdirectory with Git context
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        # subdir, taken from https://github.com/docker/build-push-action#git-context
+        context: "{{defaultContext}}:msvc"
+        push: true
+        tags: ghcr.io/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}
+env:
+  GHCR_NAMESPACE: kelvie
+  IMAGE_NAME: dfhack-build-msvc
+  # TODO: use git-describe or something? and also latest?
+  TAG_NAME: latest

--- a/msvc/Dockerfile
+++ b/msvc/Dockerfile
@@ -19,10 +19,13 @@ WORKDIR /opt/msvc
 COPY lowercase fixinclude install.sh vsdownload.py msvcenv-native.sh ./
 COPY wrappers/* ./wrappers/
 
+# This removes the arm and x86 bits to save space (around 5.5G)
 RUN PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license --dest /opt/msvc \
  && ./install.sh /opt/msvc \
  && rm lowercase fixinclude install.sh vsdownload.py \
- && rm -rf wrappers
+ && rm -rf wrappers \
+ && find /opt/msvc -depth -type d -iregex '.*/.*arm[0-9]*$' -exec rm -fr {} \; \
+ && find /opt/msvc -depth -type d -iregex '.*/.*x86$' -exec rm -fr {} \;
 
 ENV BIN=/opt/msvc/bin/x64 \
     PATH=/opt/msvc:/opt/msvc/bin/x64:/opt/git/bin:/opt/ccache/bin:/opt/cmake/bin:$PATH \


### PR DESCRIPTION
(also includes the previous PR), but I think this requires that you

1. Set up a github token: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
2. Add the token as a Repository Actions secret called  `GHCR_TOKEN` int his repo
3. After the build succeeds (and pushes), you'll need to go to your profile > packages > dfhack-build-msvc -> link it with this repo, and make the container "public".

I think (3) is necessary so you don't get billed for the large container. To make Github know it's a public container, otherwise containers over 2GB cost money, as does bandwidth I think. Not sure if this part is 100% necessary though, as I don't see anything on my billing page.